### PR TITLE
Fix: ignore linked-list exercises published before 2023

### DIFF
--- a/app/commands/user/challenges/featured_exercises_progress_12_in_23.rb
+++ b/app/commands/user/challenges/featured_exercises_progress_12_in_23.rb
@@ -16,10 +16,7 @@ class User::Challenges::FeaturedExercisesProgress12In23
       next [solved_before_23.keys.first, exercise_slug] if solved_before_23.size == track_slugs.size
     end
 
-    has_duplicate = exercises.count { |(_, exercise_slug)| MARCH_DUPLICATES.include?(exercise_slug) } == MARCH_DUPLICATES.length
-    exercises.reject! { |(_, exercise_slug)| MARCH_DUPLICATES_TO_REMOVE.include?(exercise_slug) } if has_duplicate
-
-    exercises
+    remove_march_duplicates(exercises)
   end
 
   def self.num_featured_exercises = self.featured_exercises.size - 1
@@ -47,6 +44,14 @@ class User::Challenges::FeaturedExercisesProgress12In23
       transform_values { |solutions| solutions.map { |solution| [solution[1], solution[2].year] }.to_h }
   end
 
+  def remove_march_duplicates(exercises)
+    if exercises.count { |(_, exercise_slug)| MARCH_DUPLICATES.include?(exercise_slug) } > 1
+      exercises.reject! { |(_, exercise_slug)| MARCH_DUPLICATES_TO_REMOVE.include?(exercise_slug) }
+    end
+
+    exercises
+  end
+
   FEBRUARY_TRACKS = %w[clojure elixir erlang fsharp haskell ocaml scala sml gleam].freeze
   FEBRUARY_EXERCISES = %w[hamming collatz-conjecture robot-simulator yacht protein-translation].freeze
 
@@ -54,7 +59,7 @@ class User::Challenges::FeaturedExercisesProgress12In23
   MARCH_EXERCISES = %w[linked-list simple-linked-list secret-handshake sieve binary-search pangram].freeze
 
   MARCH_DUPLICATES = %w[linked-list simple-linked-list].freeze
-  MARCH_DUPLICATES_TO_REMOVE = (MARCH_DUPLICATES - 'linked-list').freeze
+  MARCH_DUPLICATES_TO_REMOVE = (MARCH_DUPLICATES - %w[linked-list]).freeze
 
   APRIL_TRACKS = %w[julia python r].freeze
   APRIL_EXERCISES = %w[etl largest-series-product saddle-points sum-of-multiples word-count].freeze

--- a/test/commands/user/challenges/featured_exercises_progress_12_in_23_test.rb
+++ b/test/commands/user/challenges/featured_exercises_progress_12_in_23_test.rb
@@ -84,7 +84,6 @@ class User::Challenges::FeaturedExercisesProgress12In23Test < ActiveSupport::Tes
 
     linked_list_exercise = create :practice_exercise, slug: 'linked-list', track: nim
     linked_list_exercise_kotlin = create :practice_exercise, slug: 'linked-list', track: kotlin
-    linked_list_exercise_nim = create :practice_exercise, slug: 'linked-list', track: nim
     linked_list_exercise_go = create :practice_exercise, slug: 'linked-list', track: go
     simple_linked_list_exercise = create :practice_exercise, slug: 'simple-linked-list', track: nim
 

--- a/test/commands/user/challenges/featured_exercises_progress_12_in_23_test.rb
+++ b/test/commands/user/challenges/featured_exercises_progress_12_in_23_test.rb
@@ -80,9 +80,12 @@ class User::Challenges::FeaturedExercisesProgress12In23Test < ActiveSupport::Tes
     user = create :user
     nim = create :track, slug: 'nim'
     kotlin = create :track, slug: 'kotlin'
+    go = create :track, slug: 'go'
 
     linked_list_exercise = create :practice_exercise, slug: 'linked-list', track: nim
     linked_list_exercise_kotlin = create :practice_exercise, slug: 'linked-list', track: kotlin
+    linked_list_exercise_nim = create :practice_exercise, slug: 'linked-list', track: nim
+    linked_list_exercise_go = create :practice_exercise, slug: 'linked-list', track: go
     simple_linked_list_exercise = create :practice_exercise, slug: 'simple-linked-list', track: nim
 
     linked_list_solution = create :practice_solution, :published, user:, exercise: linked_list_exercise,
@@ -110,6 +113,16 @@ class User::Challenges::FeaturedExercisesProgress12In23Test < ActiveSupport::Tes
       published_at: Time.utc(2023, 3, 24)
     create :practice_solution, :published, user:, exercise: linked_list_exercise_kotlin,
       published_at: Time.utc(2023, 3, 24)
+    progress = User::Challenges::FeaturedExercisesProgress12In23.(user.reload)
+    assert_equal [[nim.slug, simple_linked_list_exercise.slug]], progress
+
+    Solution.destroy_all
+
+    # Ignore Mechanical March linked-list solution not published in 2023
+    create :practice_solution, :published, user:, exercise: simple_linked_list_exercise,
+      published_at: Time.utc(2023, 3, 24)
+    create :practice_solution, :published, user:, exercise: linked_list_exercise_go,
+      published_at: Time.utc(2022, 3, 24)
     progress = User::Challenges::FeaturedExercisesProgress12In23.(user.reload)
     assert_equal [[nim.slug, simple_linked_list_exercise.slug]], progress
   end


### PR DESCRIPTION
This PR fixes another shenanigan with the `linked-list` / `simple-linked-list` duplicate issue: if someone published a `linked-list` solution _before_ 2023 but in a language authorized for Mechanical March (Go, for example), it will prevent a submission of `simple-linked-list` in 2023 from counting toward the goal.