### PR TITLE
Fix: ignore linked-list exercises published before 2023 (tap-based)

### DIFF
--- a/app/commands/user/challenges/featured_exercises_progress_12_in_23.rb
+++ b/app/commands/user/challenges/featured_exercises_progress_12_in_23.rb
@@ -4,7 +4,7 @@ class User::Challenges::FeaturedExercisesProgress12In23
   initialize_with :user
 
   def call
-    exercises = self.class.featured_exercises.filter_map do |exercise_slug, track_slugs|
+    self.class.featured_exercises.filter_map do |exercise_slug, track_slugs|
       next unless solutions.key?(exercise_slug)
 
       solved_in_featured_tracks = solutions[exercise_slug].select { |track_slug| track_slugs.include?(track_slug) }
@@ -14,12 +14,11 @@ class User::Challenges::FeaturedExercisesProgress12In23
 
       solved_before_23 = solved_in_featured_tracks.select { |_, year| year < 2023 }
       next [solved_before_23.keys.first, exercise_slug] if solved_before_23.size == track_slugs.size
+    end.tap do |exercises|
+      if exercises.count { |(_, exercise_slug)| MARCH_DUPLICATES.include?(exercise_slug) } > 1
+        exercises.reject! { |(_, exercise_slug)| MARCH_DUPLICATES_TO_REMOVE.include?(exercise_slug) }
+      end
     end
-
-    has_duplicate = exercises.count { |(_, exercise_slug)| MARCH_DUPLICATES.include?(exercise_slug) } == MARCH_DUPLICATES.length
-    exercises.reject! { |(_, exercise_slug)| MARCH_DUPLICATES_TO_REMOVE.include?(exercise_slug) } if has_duplicate
-
-    exercises
   end
 
   def self.num_featured_exercises = self.featured_exercises.size - 1

--- a/test/commands/user/challenges/featured_exercises_progress_12_in_23_test.rb
+++ b/test/commands/user/challenges/featured_exercises_progress_12_in_23_test.rb
@@ -84,7 +84,6 @@ class User::Challenges::FeaturedExercisesProgress12In23Test < ActiveSupport::Tes
 
     linked_list_exercise = create :practice_exercise, slug: 'linked-list', track: nim
     linked_list_exercise_kotlin = create :practice_exercise, slug: 'linked-list', track: kotlin
-    linked_list_exercise_nim = create :practice_exercise, slug: 'linked-list', track: nim
     linked_list_exercise_go = create :practice_exercise, slug: 'linked-list', track: go
     simple_linked_list_exercise = create :practice_exercise, slug: 'simple-linked-list', track: nim
 

--- a/test/commands/user/challenges/featured_exercises_progress_12_in_23_test.rb
+++ b/test/commands/user/challenges/featured_exercises_progress_12_in_23_test.rb
@@ -80,9 +80,12 @@ class User::Challenges::FeaturedExercisesProgress12In23Test < ActiveSupport::Tes
     user = create :user
     nim = create :track, slug: 'nim'
     kotlin = create :track, slug: 'kotlin'
+    go = create :track, slug: 'go'
 
     linked_list_exercise = create :practice_exercise, slug: 'linked-list', track: nim
     linked_list_exercise_kotlin = create :practice_exercise, slug: 'linked-list', track: kotlin
+    linked_list_exercise_nim = create :practice_exercise, slug: 'linked-list', track: nim
+    linked_list_exercise_go = create :practice_exercise, slug: 'linked-list', track: go
     simple_linked_list_exercise = create :practice_exercise, slug: 'simple-linked-list', track: nim
 
     linked_list_solution = create :practice_solution, :published, user:, exercise: linked_list_exercise,
@@ -110,6 +113,16 @@ class User::Challenges::FeaturedExercisesProgress12In23Test < ActiveSupport::Tes
       published_at: Time.utc(2023, 3, 24)
     create :practice_solution, :published, user:, exercise: linked_list_exercise_kotlin,
       published_at: Time.utc(2023, 3, 24)
+    progress = User::Challenges::FeaturedExercisesProgress12In23.(user.reload)
+    assert_equal [[nim.slug, simple_linked_list_exercise.slug]], progress
+
+    Solution.destroy_all
+
+    # Ignore Mechanical March linked-list solution not published in 2023
+    create :practice_solution, :published, user:, exercise: simple_linked_list_exercise,
+      published_at: Time.utc(2023, 3, 24)
+    create :practice_solution, :published, user:, exercise: linked_list_exercise_go,
+      published_at: Time.utc(2022, 3, 24)
     progress = User::Challenges::FeaturedExercisesProgress12In23.(user.reload)
     assert_equal [[nim.slug, simple_linked_list_exercise.slug]], progress
   end


### PR DESCRIPTION
This is basically the same fix as #1 , but using `tap` instead of saving the exercises reference.

(Note: I did this one "blind" as I do not have access to my personal laptop right now, so I don't have the exercism website setup ready to run tests.)